### PR TITLE
chore: Fix eclipse-temurin version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:24.0.2_12-jre-alpine
+FROM eclipse-temurin:24-jre-alpine
 
 COPY target/jmxterm*-uber.jar /opt/jmxterm/jmxterm.jar
 


### PR DESCRIPTION
This pull request updates the base image used in the `Dockerfile` for building the container. The change ensures the image uses the latest tag format for the Eclipse Temurin JRE, which may improve compatibility and simplify future maintenance.

Docker image update:

* Changed the `FROM` line to use `eclipse-temurin:24-jre-alpine` instead of the more specific `eclipse-temurin:24.0.2_12-jre-alpine` in the `Dockerfile`, aligning with current tag conventions and potentially reducing maintenance overhead.