### PR TITLE
chore: Fix Docker build platforms to include arm64/v8

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -164,7 +164,7 @@ jobs:
         uses: docker/build-push-action@v6.18.0
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64/v8
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This pull request makes a small adjustment to the Docker build configuration in the GitHub Actions workflow. The change updates the target platforms for the Docker image build process.

* Docker build platforms updated in `.github/workflows/maven.yaml`: The `platforms` parameter now specifies `linux/amd64` and `linux/arm64/v8`, removing `linux/arm/v7` and refining the ARM64 architecture.