### PR TITLE
Upgrade Alpine packages in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM eclipse-temurin:24-jre-alpine
 
+RUN apk upgrade --no-cache
+
 COPY target/jmxterm*-uber.jar /opt/jmxterm/jmxterm.jar
 
 WORKDIR /opt/jmxterm


### PR DESCRIPTION
Added 'apk upgrade --no-cache' to ensure all Alpine packages are up to date when building the Docker image.