### PR TITLE
ci: Add PR conventional commit validation workflow

### DIFF
--- a/.github/workflows/conventional-pr.yaml
+++ b/.github/workflows/conventional-pr.yaml
@@ -1,0 +1,19 @@
+name: PR Conventional Commit Validation
+
+permissions:
+  pull-requests: write
+  issues: write
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened, edited ]
+
+jobs:
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR Conventional Commit Validation
+        uses: ytanikin/pr-conventional-commits@1.4.2
+        with:
+          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
+          custom_labels: '{"feat": "feature", "fix": "fix", "docs": "documentation", "test": "test", "ci": "CI/CD", "refactor": "refactor", "perf": "performance", "chore": "chore", "revert": "revert", "wip": "WIP"}'


### PR DESCRIPTION
Introduces a GitHub Actions workflow to validate pull request titles against conventional commit standards using ytanikin/pr-conventional-commits. This helps enforce consistent commit message formatting for better project maintainability.